### PR TITLE
FIX: bump to version `0.73.1`

### DIFF
--- a/scripts/community.nu
+++ b/scripts/community.nu
@@ -36,7 +36,7 @@ export def-env up [nb: int = 1] {
 # credit to @/dev/adrien#4649
 # https://discord.com/channels/601130461678272522/615253963645911060/1019056732841967647
 export def-env mkcd [name: path] {
-    cd (mkdir $name -s | first)
+    cd (mkdir $name --verbose | first)
 }
 
 

--- a/scripts/sys.nu
+++ b/scripts/sys.nu
@@ -90,7 +90,7 @@ export def mounts [
       $it.options
       | split row ","
       | split column "="
-      | if ($in | columns | any $it == column2) {
+      | if ($in | columns | any {$it == column2}) {
         transpose -i -r -d
       } else {
         get column1


### PR DESCRIPTION
This PR simply fixes the startup compilation errors thrown by `nushell` 'cause the scripts were made for the `0.72.0` :+1: 